### PR TITLE
fix: query index definition

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -24,15 +24,9 @@ indices:
       subjects:
         select: head > meta[name="subjects"]
         value: attribute(el, "content")
-      longdescription:
-        select: head > meta[name="longdescription"]
-        value: attribute(el, "content")
       publisheddateinseconds:
         select: head > meta[name="publisheddate"]
         value: parseTimestamp(attribute(el, 'content'), 'ddd, DD MMM YYYY hh:mm:ss.SSS GMT')
-      longdescription1:
-        select: main > div > p:nth-child(3)
-        value: match(innerHTML(el), '(.*?)<br><br>.*')
-      longdescription2:
-        select: main > div > p:nth-child(3)
+      longdescriptionextracted:
+        select: main > div:first-child
         value: innerHTML(el)

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,0 +1,38 @@
+version: 1
+auto-generated: false
+indices:
+  default:
+    include:
+      - /**
+    target: /query-index.json
+    properties:
+      lastModified:
+        select: none
+        value: parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")
+      title:
+        select: head > meta[property="og:title"]
+        value: attribute(el, "content")
+      description:
+        select: head > meta[name="description"]
+        value: attribute(el, "content")
+      publisheddate:
+        select: head > meta[name="publisheddate"]
+        value: attribute(el, "content")
+      industries:
+        select: head > meta[name="industries"]
+        value: attribute(el, "content")
+      subjects:
+        select: head > meta[name="subjects"]
+        value: attribute(el, "content")
+      longdescription:
+        select: head > meta[name="longdescription"]
+        value: attribute(el, "content")
+      publisheddateinseconds:
+        select: head > meta[name="publisheddate"]
+        value: parseTimestamp(attribute(el, 'content'), 'ddd, DD MMM YYYY hh:mm:ss.SSS GMT')
+      longdescription1:
+        select: main > div > p:nth-child(3)
+        value: match(innerHTML(el), '(.*?)<br><br>.*')
+      longdescription2:
+        select: main > div > p:nth-child(3)
+        value: innerHTML(el)


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix Query Index definition
Added 
- `publisheddateinseconds` - shows the published date in seconds
- `longdescriptionextracted` - first section content in main

The order of the usage will be like this (will be done in separate PR, once this is merged)
- The largest of `description` and `longdescriptionextracted`, this way we'll show something that's meaningful, rather than showing some weird characters.

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/
- After: https://query-index--accenture-newsroom--hlxsites.hlx.page/

