### PR TITLE
fix: article hero showing on top of header

### DIFF
--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -92,7 +92,6 @@
   }
 
   body.article main .section.hero-container {
-    z-index: 10;
     position: relative;
     width: 100vw;
     max-width: 100vw;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix: article hero coming on top of the header

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/news/coca-cola-bottlers-japan-and-accenture-to-establish-joint-venture
- After: https://header-fix--accenture-newsroom--hlxsites.hlx.page/news/coca-cola-bottlers-japan-and-accenture-to-establish-joint-venture

