### PR TITLE
Fix: remove newsroom posting hero-container before converting to PDF

### DIFF
--- a/blocks/aside/aside.js
+++ b/blocks/aside/aside.js
@@ -14,7 +14,9 @@ import {
 async function generatePDF(pageTitle) {
   // Source HTMLElement or a string containing HTML.
   const main = document.querySelector('main').cloneNode(true);
+  const oHeroContainer = main.querySelector('.section.hero-container');
   const asideContainer = main.querySelector('.aside-container');
+  oHeroContainer.remove();
   asideContainer.remove();
   const pageName = pageTitle.replace(/[^a-z0-9]/gi, '-');
   const { jsPDF } = window.jspdf;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #

- https://github.com/hlxsites/accenture-newsroom/issues/105

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/news/2023/accenture-completes-acquisition-of-anser-advisory
- After: https://67409-PDF-Aside--accenture-newsroom--hlxsites.hlx.page/news/2023/accenture-completes-acquisition-of-anser-advisory

