### PR TITLE
Fix: Allow link elements on the description of news card

### DIFF
--- a/blocks/newslist/newslist.js
+++ b/blocks/newslist/newslist.js
@@ -48,6 +48,10 @@ function getDescription(queryIndexEntry) {
   if (queryIndexEntry.description.length > longdescription.length) {
     return `<p>${queryIndexEntry.description}</p>`;
   }
+  const oBr = matchingParagraph.querySelector('br');
+  if (oBr) {
+    oBr.remove();
+  }
   return matchingParagraph.outerHTML;
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://github.com/hlxsites/accenture-newsroom/issues/48

- https://github.com/hlxsites/accenture-newsroom/issues/48

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/
- After: https://59797-news-card--accenture-newsroom--hlxsites.hlx.page/

