### PR TITLE
Fix: Convert anchor tag to text node before generating PDF

### DIFF
--- a/blocks/aside/aside.js
+++ b/blocks/aside/aside.js
@@ -14,21 +14,21 @@ import {
 async function generatePDF(pageTitle) {
   // Source HTMLElement or a string containing HTML.
   const main = document.querySelector('main').cloneNode(true);
-  const oHeroContainer = main.querySelector('.section.hero-container');
+  const heroContainer = main.querySelector('.section.hero-container');
   const asideContainer = main.querySelector('.aside-container');
-  const oAllParagraphs = main.querySelectorAll('p');
-  oHeroContainer.remove();
+  const allParagraphs = main.querySelectorAll('p');
+  heroContainer.remove();
   asideContainer.remove();
   const pageName = pageTitle.replace(/[^a-z0-9]/gi, '-');
 
-  oAllParagraphs.forEach((oParagraph) => {
-    const oAnchorElements = oParagraph.querySelectorAll('a');
-    if (oAnchorElements.length === 0) {
+  allParagraphs.forEach((paragraph) => {
+    const anchorElements = paragraph.querySelectorAll('a');
+    if (anchorElements.length === 0) {
       return;
     }
-    oAnchorElements.forEach((oElement) => {
-      const oInnerText = document.createTextNode(oElement.innerText);
-      oElement.parentNode.replaceChild(oInnerText, oElement);
+    anchorElements.forEach((el) => {
+      const innerText = document.createTextNode(el.innerText);
+      el.parentNode.replaceChild(innerText, el);
     });
   });
 

--- a/blocks/aside/aside.js
+++ b/blocks/aside/aside.js
@@ -16,9 +16,22 @@ async function generatePDF(pageTitle) {
   const main = document.querySelector('main').cloneNode(true);
   const oHeroContainer = main.querySelector('.section.hero-container');
   const asideContainer = main.querySelector('.aside-container');
+  const oAllParagraphs = main.querySelectorAll('p');
   oHeroContainer.remove();
   asideContainer.remove();
   const pageName = pageTitle.replace(/[^a-z0-9]/gi, '-');
+
+  oAllParagraphs.forEach((oParagraph) => {
+    const oAnchorElements = oParagraph.querySelectorAll('a');
+    if (oAnchorElements.length === 0) {
+      return;
+    }
+    oAnchorElements.forEach((oElement) => {
+      const oInnerText = document.createTextNode(oElement.innerText);
+      oElement.parentNode.replaceChild(oInnerText, oElement);
+    });
+  });
+
   const { jsPDF } = window.jspdf;
   // eslint-disable-next-line new-cap
   const doc = new jsPDF();


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://github.com/hlxsites/accenture-newsroom/issues/133

- https://github.com/hlxsites/accenture-newsroom/issues/133

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/news/2023/accenture-completes-acquisition-of-anser-advisory
- After: https://84836-PDF-Links--accenture-newsroom--hlxsites.hlx.page/news/2023/accenture-completes-acquisition-of-anser-advisory

