### PR TITLE
Fix: add styling to Home hero card title link

### DIFF
--- a/blocks/home-hero/home-hero.css
+++ b/blocks/home-hero/home-hero.css
@@ -73,14 +73,6 @@
   margin-bottom: 10px;
 }
 
-.home-hero.block .overlay-container h2 a{
-  color: #000;
-}
-
-.home-hero.block .overlay-container h2 a::after{
-  display: none;
-}
-
 .home-hero.block .overlay-container p {
   margin: 0 0 10px ;
 }
@@ -97,6 +89,14 @@
   width: 40px;
   line-height: 20px;
   background: transparent url('/icons/arrow-icon.svg') no-repeat 0 -8px;
+}
+
+.home-hero.block .overlay-container h2 a{
+  color: #000;
+}
+
+.home-hero.block .overlay-container h2 a::after{
+  display: none;
 }
 
 @media (min-width: 1000px) {

--- a/blocks/home-hero/home-hero.css
+++ b/blocks/home-hero/home-hero.css
@@ -73,6 +73,14 @@
   margin-bottom: 10px;
 }
 
+.home-hero.block .overlay-container h2 a{
+  color: #000;
+}
+
+.home-hero.block .overlay-container h2 a::after{
+  display: none;
+}
+
 .home-hero.block .overlay-container p {
   margin: 0 0 10px ;
 }

--- a/blocks/home-hero/home-hero.css
+++ b/blocks/home-hero/home-hero.css
@@ -81,6 +81,14 @@
   display: none;
 }
 
+.home-hero.block .overlay-container h2 a{
+  color: #000;
+}
+
+.home-hero.block .overlay-container h2 a::after{
+  display: none;
+}
+
 .home-hero.block .overlay-container a::after,
 .home-hero.block .home-hero-links-container ul li a::after {
   content: '';
@@ -89,14 +97,6 @@
   width: 40px;
   line-height: 20px;
   background: transparent url('/icons/arrow-icon.svg') no-repeat 0 -8px;
-}
-
-.home-hero.block .overlay-container h2 a{
-  color: #000;
-}
-
-.home-hero.block .overlay-container h2 a::after{
-  display: none;
 }
 
 @media (min-width: 1000px) {

--- a/blocks/home-hero/home-hero.css
+++ b/blocks/home-hero/home-hero.css
@@ -81,14 +81,6 @@
   display: none;
 }
 
-.home-hero.block .overlay-container h2 a{
-  color: #000;
-}
-
-.home-hero.block .overlay-container h2 a::after{
-  display: none;
-}
-
 .home-hero.block .overlay-container a::after,
 .home-hero.block .home-hero-links-container ul li a::after {
   content: '';
@@ -97,6 +89,14 @@
   width: 40px;
   line-height: 20px;
   background: transparent url('/icons/arrow-icon.svg') no-repeat 0 -8px;
+}
+
+.home-hero.block .home-hero-content-container .overlay-container h2 a{
+  color: #000;
+}
+
+.home-hero.block .home-hero-content-container .overlay-container h2 a::after{
+  display: none;
 }
 
 @media (min-width: 1000px) {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://github.com/hlxsites/accenture-newsroom/issues/149

- https://github.com/hlxsites/accenture-newsroom/issues/149

- need to update the authoring of card title and add link to it. I attached my demo testpage and add link to the card title then css will remove the arrow and color of it to make it look the same with the legacy page.

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/drafts/jaspher/demo
- After: https://85035-hero-title--accenture-newsroom--hlxsites.hlx.page/drafts/jaspher/demo
- After: https://85035-hero-title--accenture-newsroom--hlxsites.hlx.page/

