### PR TITLE
Fix: Remove first br tag for the news card

### DIFF
--- a/blocks/newslist/newslist.js
+++ b/blocks/newslist/newslist.js
@@ -50,6 +50,10 @@ function getDescription(queryIndexEntry) {
   div.innerHTML = longdescriptionextracted;
   const longdescriptionElements = Array.from(div.querySelectorAll('p'));
   const matchingParagraph = longdescriptionElements.find((p) => ABSTRACT_REGEX.test(p.innerText));
+  const oBr = matchingParagraph.querySelector('br');
+  if (oBr) {
+    oBr.remove();
+  }
   let longdescription = matchingParagraph ? matchingParagraph.outerHTML : '';
   if (queryIndexEntry.description.length > longdescription.length) {
     longdescription = `<p>${queryIndexEntry.description}</p>`;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://github.com/hlxsites/accenture-newsroom/issues/216

- https://github.com/hlxsites/accenture-newsroom/issues/216

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/
- After: https://143053-br-newscard--accenture-newsroom--hlxsites.hlx.page/

it seems this part of the code was deleted. 
https://github.com/hlxsites/accenture-newsroom/pull/130#discussion_r1334747190

