### PR TITLE
Fix: add null check to the matchingParagraph variable

### DIFF
--- a/blocks/newslist/newslist.js
+++ b/blocks/newslist/newslist.js
@@ -50,11 +50,9 @@ function getDescription(queryIndexEntry) {
   div.innerHTML = longdescriptionextracted;
   const longdescriptionElements = Array.from(div.querySelectorAll('p'));
   const matchingParagraph = longdescriptionElements.find((p) => ABSTRACT_REGEX.test(p.innerText));
-  if (matchingParagraph) {
-    const oBr = matchingParagraph.querySelector('br');
-    if (oBr) {
-      oBr.remove();
-    }
+  const oBr = matchingParagraph?.querySelector('br');
+  if (oBr) {
+    oBr.remove();
   }
   let longdescription = matchingParagraph ? matchingParagraph.outerHTML : '';
   if (queryIndexEntry.description.length > longdescription.length) {

--- a/blocks/newslist/newslist.js
+++ b/blocks/newslist/newslist.js
@@ -52,10 +52,9 @@ function getDescription(queryIndexEntry) {
   const matchingParagraph = longdescriptionElements.find((p) => ABSTRACT_REGEX.test(p.innerText));
   if (matchingParagraph) {
     const oBr = matchingParagraph.querySelector('br');
-    if (!oBr) {
-      return;
+    if (oBr) {
+      oBr.remove();
     }
-    oBr.remove();
   }
   let longdescription = matchingParagraph ? matchingParagraph.outerHTML : '';
   if (queryIndexEntry.description.length > longdescription.length) {

--- a/blocks/newslist/newslist.js
+++ b/blocks/newslist/newslist.js
@@ -50,8 +50,11 @@ function getDescription(queryIndexEntry) {
   div.innerHTML = longdescriptionextracted;
   const longdescriptionElements = Array.from(div.querySelectorAll('p'));
   const matchingParagraph = longdescriptionElements.find((p) => ABSTRACT_REGEX.test(p.innerText));
-  const oBr = matchingParagraph.querySelector('br');
-  if (oBr) {
+  if (matchingParagraph) {
+    const oBr = matchingParagraph.querySelector('br');
+    if (!oBr) {
+      return;
+    }
     oBr.remove();
   }
   let longdescription = matchingParagraph ? matchingParagraph.outerHTML : '';


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://github.com/hlxsites/accenture-newsroom/issues/224

- https://github.com/hlxsites/accenture-newsroom/issues/224

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/
- Before: https://main--accenture-newsroom-jp--hlxsites.hlx.page/
- After: https://149585-newsfeed--accenture-newsroom--hlxsites.hlx.page/
- After: https://149585-newsfeed--accenture-newsroom-jp--hlxsites.hlx.page/

there's a console error for some geos caused by undefined matchingParagraph querySelector br element,
Fix: Add null check to  matchingParagraph before querySector of br element
![image](https://github.com/hlxsites/accenture-newsroom/assets/142872664/a327cb03-8e76-4f35-b37e-b2e77d08aabe)

![image](https://github.com/hlxsites/accenture-newsroom/assets/142872664/5533544e-4515-474b-98d2-e7546061de77)

Local JP geo
![image](https://github.com/hlxsites/accenture-newsroom/assets/142872664/c2149387-15e9-46d3-97de-489583085142)



