### PR TITLE
Sidekick tagger

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,0 +1,20 @@
+{
+  "project": "Accenture Newsroom",
+  "host": "main--accenture-newsroom--hlxsites.hlx.live",
+  "plugins": [
+      {
+          "id": "publish",
+
+        "excludePaths": [
+          "**/drafts/**",
+          "**%2Fdrafts**"
+        ]
+      },
+      {
+          "id": "tagger",
+          "title": "Tagger",
+          "environments": [ "edit" ],
+          "url": "/tools/tagger/index.html"
+        }
+  ]
+}

--- a/tools/tagger/index.html
+++ b/tools/tagger/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Accenture Newsroom - Tagger</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <script src="/tools/tagger/tagger.js" type="module"></script>
+  <link rel="stylesheet" href="/tools/tagger/tagger.css"/>
+</head>
+<body>
+<div id="tags-data"></div>
+<main>
+  <div class="intro">
+    <h1 id="pick-your-tags">Search + copy your tags</h1>
+    <p>Use this page to search and choose the relevant tags for your pages, without fear of misspelling or forgetting any.</p>
+    <p>Once you click on a tag, it will populate at the bottom of the page. Re-clicking a tag will de-select it. When you have picked all the tags, click
+      “copy” and then paste the information directly in your page's metadata (only the solid colored words will be copied, not the whole path). Use the 'clear' button if you want to start over.</p>
+    <ul>
+      <li><strong>Subjects</strong> = tag the article with these subjects</li>
+      <li><strong>Industries</strong> = tag the article with these industries</li>
+    </ul>
+  </div>
+  <div class="filter">
+    <input autocomplete="off" placeholder="Type to filter" id="search">
+  </div>
+  <div id="results"></div>
+  <div id="selected" class="hidden">
+    <div class="selected-tags"></div>
+    <div>
+      <button class="copy">Copy</button>
+      <button class="clear">Clear</button>
+    </div>
+  </div>
+</main>
+<textarea class="offscreen" id="copybuffer"></textarea>
+</body>
+</html>

--- a/tools/tagger/tagger.css
+++ b/tools/tagger/tagger.css
@@ -1,0 +1,170 @@
+body {
+  background-color: #FAF8F6;
+}
+
+main .intro {
+  font-size: 1.2rem;
+}
+
+main input {
+  width: 100%;
+  font-size: 2rem;
+  border: none;
+  border-bottom: solid 1px grey;
+  padding-top: 5px;
+  font-family: inherit;
+}
+
+main .filter {
+  padding: 20px 10px;
+}
+
+#selected {
+  position: fixed;
+  bottom: 0;
+  background-color: #E7E2DA;
+  padding-bottom: 20px;
+  width: 100%;
+  box-sizing: border-box;
+  left: 0;
+  display: grid;
+  gap: 1rem
+}
+
+main #selected {
+  padding: 30px;
+}
+
+#selected button {
+  background-color: #F25749;
+  color: white;
+  border: 1px solid white;
+  font-size: 13px;
+}
+
+main #selected button {
+  border-radius: 1em;
+  padding: 5px 20px;
+}
+
+#results {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  padding-bottom: 350px;
+}
+
+#results > .category {
+  user-select: none;
+  display: flex;
+  flex-flow: column wrap;
+}
+
+main > div > span,
+main > div > div > span {
+  white-space: nowrap;
+  margin: 6px 4px;
+}
+
+main {
+  font-family: system-ui, Arial;
+  padding: 20px;
+  font-size: 1.3rem;
+  line-height: 1.2em;
+}
+
+span.tag {
+  color: white;
+  padding: 2px 20px;
+  border-radius: 10px;
+  font-size: 16px;
+}
+
+.tag {
+  padding-top: 5px;
+}
+
+.selected span.tag {
+  background-color: #888;
+  color: lightgrey;
+}
+
+.tag.cat-0 {
+  background-color: #1385E2;
+}
+
+.tag.cat-1 {
+  background-color: #FA1E32;
+}
+
+.tag.cat-2 {
+  background-color: #05BC71
+}
+
+.tag.cat-3 {
+  background-color: #90F;
+}
+
+.tag.cat-4 {
+  background-color: black;
+}
+
+.tag.cat-5 {
+  background-color: #059641;
+}
+
+.tag.cat-6 {
+  background-color: #D21313;
+}
+
+.tag.cat-7 {
+  background-color: deepskyblue;
+}
+
+span.tag .highlight {
+  font-weight: 700;
+  color: white;
+}
+
+span.path {
+  cursor: pointer;
+  border-radius: 10px;
+  border: 1px dashed black;
+  padding: 4px 10px 2px;
+  font-size: 12px;
+}
+
+span.path.filtered {
+  display: none;
+}
+
+span.psep {
+  font-size: 20px;
+  font-weight: bold;
+}
+
+@media (min-width: 600px) {
+  #selected {
+    grid-template-columns: 1fr 100px;
+  }
+}
+
+#selected button:disabled {
+  background-color: #ccc;
+  color: grey;
+}
+
+.selected-tags {
+  display: flex;
+  flex-wrap: wrap;
+  height: min-content;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.offscreen {
+  position: absolute;
+  top: -1000px;
+}

--- a/tools/tagger/tagger.js
+++ b/tools/tagger/tagger.js
@@ -1,0 +1,117 @@
+function renderItems(cat, catId, taxonomy) {
+  let html = '';
+  const items = taxonomy.map((item) => item[cat]);
+  items.forEach((tag) => {
+    if (tag.trim() !== '') {
+      html += `
+      <span class="path">
+        <span data-title="${tag}" class="tag cat-${catId % 8}">${tag}</span>
+      </span>
+    `;
+    }
+  });
+  return html;
+}
+
+function initTaxonomy(taxonomy) {
+  let html = '';
+  Object.keys(taxonomy[0]).forEach((cat, idx) => {
+    html += '<div class="category">';
+    html += `<h2>${cat}</h2>`;
+    html += renderItems(cat, idx, taxonomy);
+    html += '</div>';
+  });
+  const results = document.getElementById('results');
+  results.innerHTML = html;
+}
+
+async function getTaxonomy() {
+  const resp = await fetch('/tags.json');
+  const tagsJson = await resp.json();
+  return tagsJson.data;
+}
+
+function filter() {
+  const searchTerm = document.getElementById('search').value.toLowerCase();
+  document.querySelectorAll('#results .tag').forEach((tag) => {
+    const { title } = tag.dataset;
+    const offset = title.toLowerCase().indexOf(searchTerm);
+    if (offset >= 0) {
+      const before = title.substring(0, offset);
+      const term = title.substring(offset, offset + searchTerm.length);
+      const after = title.substring(offset + searchTerm.length);
+      tag.innerHTML = `${before}<span class="highlight">${term}</span>${after}`;
+      tag.closest('.path').classList.remove('filtered');
+    } else {
+      tag.closest('.path').classList.add('filtered');
+    }
+  });
+}
+
+function toggleTag(target) {
+  target.classList.toggle('selected');
+  // eslint-disable-next-line no-use-before-define
+  displaySelected();
+}
+
+function displaySelected() {
+  const selEl = document.getElementById('selected');
+  const selTagsEl = selEl.querySelector('.selected-tags');
+  const toCopyBuffer = [];
+
+  selTagsEl.innerHTML = '';
+  const selectedTags = document.querySelectorAll('#results .path.selected');
+  if (selectedTags.length > 0) {
+    selectedTags.forEach((path) => {
+      const clone = path.cloneNode(true);
+      clone.classList.remove('filtered', 'selected');
+      const tag = clone.querySelector('.tag');
+      tag.innerHTML = tag.dataset.title;
+      clone.addEventListener('click', () => {
+        toggleTag(path);
+      });
+      toCopyBuffer.push(tag.dataset.title);
+      selTagsEl.append(clone);
+    });
+
+    selEl.classList.remove('hidden');
+  } else {
+    selEl.classList.add('hidden');
+  }
+
+  const copybuffer = document.getElementById('copybuffer');
+  copybuffer.value = toCopyBuffer.join(', ');
+}
+
+async function init() {
+  const tax = await getTaxonomy();
+
+  initTaxonomy(tax);
+
+  const selEl = document.getElementById('selected');
+  const copyButton = selEl.querySelector('button.copy');
+  copyButton.addEventListener('click', () => {
+    const copyText = document.getElementById('copybuffer');
+    navigator.clipboard.writeText(copyText.value);
+
+    copyButton.disabled = true;
+  });
+
+  selEl.querySelector('button.clear').addEventListener('click', () => {
+    const selectedTags = document.querySelectorAll('#results .path.selected');
+    selectedTags.forEach((tag) => {
+      toggleTag(tag);
+    });
+  });
+
+  document.querySelector('#search').addEventListener('keyup', filter);
+
+  document.addEventListener('click', (e) => {
+    const target = e.target.closest('.category .path');
+    if (target) {
+      toggleTag(target);
+    }
+  });
+}
+
+init();


### PR DESCRIPTION
Adding tagger functionality to show up during editing.

It reads from /tags.json (tags is an excel file with subjects and industries as two columns)

Fix #15 

No before/after since this is sidekick functionality.

See screenshot of working tagger below:

![Screenshot 2023-10-02 at 10 53 07 PM](https://github.com/hlxsites/accenture-newsroom/assets/7074782/b2d7935c-8d54-4586-bad2-f2b43a46f1ae)

