### PR TITLE
updating csp list

### DIFF
--- a/scripts/csp.json
+++ b/scripts/csp.json
@@ -9,7 +9,6 @@
       "rum.hlx.page",
       "assets.adobedtm.com",
       "cdn.cookielaw.org",
-      "https://*.cookielaw.org",
       "www.youtube.com",
       "dpm.demdex.net",
       "cdnjs.cloudflare.com"
@@ -31,12 +30,14 @@
     "*.accenture.com",
     "assets.adobedtm.com",
     "cdn.cookielaw.org",
-    "cm.everesttech.net"
+    "cm.everesttech.net",
+    "*.demdex.net"
   ],
   "frame-src": [
     "'self'",
     "*.accenture.com",
-    "www.youtube.com"
+    "www.youtube.com",
+    "*.demdex.net"
   ],
   "style-src": [
     "'self'",


### PR DESCRIPTION
adding some more domains that were missing the first time

Fix #257 

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/
- After: https://csp-updates--accenture-newsroom--hlxsites.hlx.page/

