### PR TITLE
Fix: remove title attribute on the section articles link

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -504,6 +504,7 @@ function annotateArticleSections() {
       return;
     }
     section.querySelectorAll('a').forEach((link) => {
+      link.removeAttribute('title');
       annotateElWithAnalyticsTracking(
         link,
         link.innerText,


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://github.com/hlxsites/accenture-newsroom/issues/135

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/news/2023/accenture-completes-acquisition-of-anser-advisory
- After: https://86038-Tooltip--accenture-newsroom--hlxsites.hlx.page/news/2023/accenture-completes-acquisition-of-anser-advisory

