### PR TITLE
fix: updating the category page import to use the tag name instead of title

### DIFF
--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -108,15 +108,15 @@ const createNewsListBlock = (main, document, url) => {
   const cells = [
     ['Newslist'],
   ];
-  const titleEl = main.querySelector('#sec-hero h1');
-  let title = '';
-  if (titleEl) {
-    title = titleEl.textContent.trim();
+  let { pathname } = new URL(url);
+  if (pathname.endsWith('/')) {
+    pathname = pathname.slice(0, -1);
   }
+  const tagName = pathname.split('/').pop();
   if (url.includes('/industries/') || url.includes('/secteurs-dactivit/')) {
-    cells.push(['Industries', title]);
+    cells.push(['Industries', tagName]);
   } else if (url.includes('/subjects/') || url.includes('/sujet/') || url.includes('/argomento/')) {
-    cells.push(['Subjects', title]);
+    cells.push(['Subjects', tagName]);
   }
   const table = WebImporter.DOMUtils.createTable(cells, document);
   categoryContainer.replaceWith(table);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix the category page import to use tag name instead of title

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/
- After: https://import-category-pages--accenture-newsroom--hlxsites.hlx.page/

