### PR TITLE
67470- article prev and next link load time fix

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -795,8 +795,7 @@ async function loadSemiDelayed() {
  * without impacting the user experience.
  */
 function loadDelayed() {
-  // article processing
-  window.setTimeout(() => loadSemiDelayed(), 2000);
+  // article processin
   // eslint-disable-next-line import/no-cycle
   window.setTimeout(() => import('./delayed.js'), 3000);
   // load anything that can be postponed to the latest here
@@ -805,6 +804,7 @@ function loadDelayed() {
 async function loadPage() {
   await loadEager(document);
   await loadLazy(document);
+  await loadSemiDelayed();
   loadDelayed();
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #189 

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.live/news/2023/accenture-to-acquire-einr-as-expanding-sap-supply-chain-and-logistics-capabilities-in-the-nordics
- After: https://67470-prev-next-link--accenture-newsroom--hlxsites.hlx.live/news/2023/accenture-to-acquire-einr-as-expanding-sap-supply-chain-and-logistics-capabilities-in-the-nordics
- After: https://67470-prev-next-link--accenture-newsroom--hlxsites.hlx.live/news/2018/accenture-interactive-completes-acquisition-of-new-content-a-brazilian-marketing-agency

