### PR TITLE
fix: accented characters in subjects/industries

### DIFF
--- a/blocks/aside/aside.js
+++ b/blocks/aside/aside.js
@@ -4,6 +4,7 @@ import {
   createEl,
   getPlaceholder,
   getSiteFromHostName,
+  sanitizeName,
 } from '../../scripts/scripts.js';
 import {
   decorateIcons,
@@ -178,15 +179,18 @@ export default async function decorate(block) {
   const subjectTagValues = getMetadata('subjects');
   const industryEl = industryTagValues ? createEl('div', { class: 'industry' }, `<h4>${pIndustryTags}</h4>`) : null;
   const subjectEl = subjectTagValues ? createEl('div', { class: 'subject' }, `<h4>${pSubjectTags}</h4>`) : null;
-  let siteName = getSiteFromHostName(window.location.hostname);
+  const siteName = getSiteFromHostName(window.location.hostname);
+  let sitePrefix = '';
   if (siteName === 'us') {
-    siteName = '';
+    sitePrefix = '';
+  } else {
+    sitePrefix = `/${siteName}`;
   }
 
   const industryUl = industryEl ? createEl('ul', {}, '', industryEl) : null;
   industryTagValues.split(',').forEach((industryTag) => {
-    const cleanedUpValue = industryTag.trim().toLowerCase().replace(/[\W_]+/g, '-');
-    const link = createEl('a', { href: `${siteName}/industries/${cleanedUpValue}` }, getTagTitle(cleanedUpValue, placeholders, industryTag.trim()));
+    const cleanedUpValue = sanitizeName(industryTag);
+    const link = createEl('a', { href: `${sitePrefix}/industries/${cleanedUpValue}` }, getTagTitle(cleanedUpValue, placeholders, industryTag.trim()));
     annotateElWithAnalyticsTracking(
       link,
       link.textContent,
@@ -199,10 +203,8 @@ export default async function decorate(block) {
 
   const subjectUl = subjectEl ? createEl('ul', {}, '', subjectEl) : null;
   subjectTagValues.split(',').forEach((subjectTag) => {
-    const cleanedUpValue = subjectTag.trim().toLowerCase().replace(/&/g, 'and')
-      .replace(/[/]/g, '')
-      .replace(/[\W_]+/g, '-');
-    const link = createEl('a', { href: `${siteName}/subjects/${cleanedUpValue}` }, getTagTitle(cleanedUpValue, placeholders, subjectTag.trim()));
+    const cleanedUpValue = sanitizeName(subjectTag);
+    const link = createEl('a', { href: `${sitePrefix}/subjects/${cleanedUpValue}` }, getTagTitle(cleanedUpValue, placeholders, subjectTag.trim()));
     annotateElWithAnalyticsTracking(
       link,
       link.textContent,

--- a/blocks/newslist/newslist.js
+++ b/blocks/newslist/newslist.js
@@ -10,6 +10,7 @@ import {
   getCountry,
   getDateLocales,
   isMobile,
+  sanitizeName,
 } from '../../scripts/scripts.js';
 import {
   ANALYTICS_MODULE_SEARCH,
@@ -259,7 +260,8 @@ function addEventListenerToFilterForm(block) {
 
 function ifArticleBelongsToCategories(article, key, value) {
   const values = article[key.trim()].toLowerCase().split(',').map((v) => v.trim());
-  if (values.includes(value.trim().toLowerCase())) {
+  const sanitizedValue = sanitizeName(value);
+  if (values.includes(value.trim().toLowerCase()) || values.includes(sanitizedValue)) {
     return true;
   }
   return false;

--- a/blocks/newslist/newslist.js
+++ b/blocks/newslist/newslist.js
@@ -10,7 +10,6 @@ import {
   getCountry,
   getDateLocales,
   isMobile,
-  sanitizeName,
 } from '../../scripts/scripts.js';
 import {
   ANALYTICS_MODULE_SEARCH,
@@ -260,8 +259,7 @@ function addEventListenerToFilterForm(block) {
 
 function ifArticleBelongsToCategories(article, key, value) {
   const values = article[key.trim()].toLowerCase().split(',').map((v) => v.trim());
-  const sanitizedValue = sanitizeName(value);
-  if (values.includes(value.trim().toLowerCase()) || values.includes(sanitizedValue)) {
+  if (values.includes(value.trim().toLowerCase())) {
     return true;
   }
   return false;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -112,6 +112,18 @@ export function getDateLocales(country) {
   return countryDateLocales[country] || 'en-US';
 }
 
+/**
+ * Removes Diacritics (accented characters) from a string
+ * @param {*} name
+ * @returns
+ */
+export function sanitizeName(name) {
+  return name ? decodeURIComponent(name.trim()).toLowerCase().normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '') : '';
+}
+
 export function getPlaceholder(key, placeholders) {
   if (placeholders && placeholders[key]) {
     return placeholders[key];

--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+
 /* eslint-disable no-undef */
 const isCategoryPage = (url) => {
   const { pathname } = new URL(url);
@@ -87,7 +88,11 @@ const createMetadataBlock = (main, document, url) => {
         industryHref = industryHref.slice(0, -1);
       }
       const industryName = industryHref.split('/').pop();
-      industryTags.push(industryName);
+      let sanitizedName = WebImporter.FileUtils.sanitizePath(industryName);
+      if (sanitizedName.startsWith('/')) {
+        sanitizedName = sanitizedName.slice(1);
+      }
+      industryTags.push(sanitizedName);
     });
     meta.Industries = industryTags.join(', ');
   }
@@ -101,7 +106,11 @@ const createMetadataBlock = (main, document, url) => {
         subjectHref = subjectHref.slice(0, -1);
       }
       const subjectName = subjectHref.split('/').pop();
-      subjectTags.push(subjectName);
+      let sanitizedName = WebImporter.FileUtils.sanitizePath(subjectName);
+      if (sanitizedName.startsWith('/')) {
+        sanitizedName = sanitizedName.slice(1);
+      }
+      subjectTags.push(sanitizedName);
     });
     meta.Subjects = subjectTags.join(', ');
   }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix accented characters in subjects/industries

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.live/
- After: https://tags-accented--accenture-newsroom--hlxsites.hlx.live/subjects/supply-chain-management
- After: https://tags-accented--accenture-newsroom--hlxsites.hlx.live/
- After: https://tags-accented--accenture-newsroom--hlxsites.hlx.live/news/2023/three-in-four-semiconductor-executives-expect-supply-chain-challenges-to-ease-by-2024-accenture-report-finds

