### PR TITLE
fix: assume that first section in the doc is abstract

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -508,25 +508,18 @@ function annotateArticleSections() {
   if (template !== 'Article') {
     return;
   }
-  const articleSections = document.querySelectorAll('main > .section');
-
-  // eslint-disable-next-line no-restricted-syntax
-  for (const section of articleSections) {
-    const sectionText = section.innerText;
-    const isAbstract = ABSTRACT_REGEX.test(sectionText);
-    if (isAbstract) {
-      section.classList.add('abstract');
-      const h1 = section.querySelector('h1');
-      if (h1) {
-        const date = h1.previousSibling;
-        if (date) {
-          date.classList.add('date');
-        }
-      }
-      break;
+  // add abstract and date classes
+  const abstractSection = document.querySelector('main > .section:not(.hero-container)');
+  abstractSection.classList.add('abstract');
+  const h1 = abstractSection.querySelector('h1');
+  if (h1) {
+    const date = h1.previousSibling;
+    if (date) {
+      date.classList.add('date');
     }
   }
   // annotate links
+  const articleSections = document.querySelectorAll('main > .section');
   const excludeSections = ['hero-container', 'aside-container'];
   articleSections.forEach((section) => {
     const sectionClassList = Array.from(section.classList);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -309,7 +309,7 @@ body.article main .section.abstract p.date {
   margin: 0;
 }
 
-body.article main .section.abstract h1 {
+body.article main .section h1 {
   text-align: center;
   font-family: var(--header-font-family-regular);
   font-weight: 700;


### PR DESCRIPTION

Fix - assume the first section as abstract rather than matching with regex to find the abstract, given that we've imported the abstract for most of the articles.

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.live/
- After: https://simplify-abstract--accenture-newsroom--hlxsites.hlx.live/
- Before: https://main--accenture-newsroom--hlxsites.hlx.live/news/2023/ceos-lack-confidence-in-their-organizations-ability-to-protect-against-cyberattacks-despite-seeing-cybersecurity-as-vital-to-growth-accenture-report-finds
- After: https://simplify-abstract--accenture-newsroom--hlxsites.hlx.live/news/2023/ceos-lack-confidence-in-their-organizations-ability-to-protect-against-cyberattacks-despite-seeing-cybersecurity-as-vital-to-growth-accenture-report-finds

cc: @raymond-h-dev @veejayricana @jjjaspher please test in this new branch and let me know if this works once you've fixed the abstracts. This should simplify and depend on the content to tell us which section is the abstract.
