### PR TITLE
fix: aside height to fully show the aside container

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -35,7 +35,6 @@ const LCP_BLOCKS = []; // add your LCP blocks to the list
 export const ABSTRACT_REGEX = /(.*?);.*?(\d{4})|(.*?)(\d{4})\s+–\s+\b|(.*?)(\d{4})\s+-\s+\b/;
 
 export const isMobile = () => window.innerWidth < 600;
-export const isDesktop = () => window.innerWidth >= 900;
 
 export function getSiteFromHostName(hostname = window.location.hostname) {
   const allowedSites = ['uk', 'de', 'fr', 'it', 'es', 'sg', 'pt', 'jp', 'br'];
@@ -762,28 +761,6 @@ const preflightListener = async () => {
 };
 
 /**
- * set the height of the last section to completely show the aside
- */
-function handleAsideSectionHeight() {
-  const excludeSections = ['hero-container', 'aside-container'];
-  const aside = document.querySelector('.aside-container');
-  const asideHeight = aside ? aside.offsetHeight : 0;
-  let totalSectionHeght = 0;
-  const sections = document.querySelectorAll('main .section');
-  sections.forEach((section) => {
-    const sectionClass = section.className.replace('section ', '').trim();
-    if (!excludeSections.includes(sectionClass)) {
-      totalSectionHeght += section.offsetHeight;
-    }
-  });
-  if (totalSectionHeght < asideHeight) {
-    const lastSection = sections[sections.length - 2];
-    const minHeight = asideHeight - totalSectionHeght + lastSection.offsetHeight;
-    lastSection.style.minHeight = `${minHeight}px`;
-  }
-}
-
-/**
  * Loads everything that doesn't need to be delayed.
  * @param {Element} doc The container element
  */
@@ -791,9 +768,6 @@ async function loadLazy(doc) {
   await setCSP();
   const main = doc.querySelector('main');
   await loadBlocks(main);
-  if (isDesktop()) {
-    handleAsideSectionHeight();
-  }
 
   const { hash } = window.location;
   const element = hash ? doc.getElementById(hash.substring(1)) : false;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -35,6 +35,7 @@ const LCP_BLOCKS = []; // add your LCP blocks to the list
 export const ABSTRACT_REGEX = /(.*?);.*?(\d{4})|(.*?)(\d{4})\s+–\s+\b|(.*?)(\d{4})\s+-\s+\b/;
 
 export const isMobile = () => window.innerWidth < 600;
+export const isDesktop = () => window.innerWidth >= 900;
 
 export function getSiteFromHostName(hostname = window.location.hostname) {
   const allowedSites = ['uk', 'de', 'fr', 'it', 'es', 'sg', 'pt', 'jp', 'br'];
@@ -761,6 +762,28 @@ const preflightListener = async () => {
 };
 
 /**
+ * set the height of the last section to completely show the aside
+ */
+function handleAsideSectionHeight() {
+  const excludeSections = ['hero-container', 'aside-container'];
+  const aside = document.querySelector('.aside-container');
+  const asideHeight = aside ? aside.offsetHeight : 0;
+  let totalSectionHeght = 0;
+  const sections = document.querySelectorAll('main .section');
+  sections.forEach((section) => {
+    const sectionClass = section.className.replace('section ', '').trim();
+    if (!excludeSections.includes(sectionClass)) {
+      totalSectionHeght += section.offsetHeight;
+    }
+  });
+  if (totalSectionHeght < asideHeight) {
+    const lastSection = sections[sections.length - 2];
+    const minHeight = asideHeight - totalSectionHeght + lastSection.offsetHeight;
+    lastSection.style.minHeight = `${minHeight}px`;
+  }
+}
+
+/**
  * Loads everything that doesn't need to be delayed.
  * @param {Element} doc The container element
  */
@@ -768,6 +791,9 @@ async function loadLazy(doc) {
   await setCSP();
   const main = doc.querySelector('main');
   await loadBlocks(main);
+  if (isDesktop()) {
+    handleAsideSectionHeight();
+  }
 
   const { hash } = window.location;
   const element = hash ? doc.getElementById(hash.substring(1)) : false;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -338,6 +338,9 @@ body.article main .section .article-end-divider {
 
   body.article main {
     max-width: 1200px;
+
+    /* height of aside 450px and hero container height 160px, so setting the min height to 610px */
+    min-height: 610px;
     margin: auto;
     position: relative;
   }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #368

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.live//news/2023/accenture-reports-strong-third-quarter-fiscal-2023-results
- Before: https://main--accenture-newsroom--hlxsites.hlx.live/news/2023/accenture-federal-services-and-google-public-sector-launch-cybersecurity-center-of-excellence
- After: https://aside-height--accenture-newsroom--hlxsites.hlx.live/news/2023/accenture-reports-strong-third-quarter-fiscal-2023-results
- After: https://aside-height--accenture-newsroom--hlxsites.hlx.live/news/2023/accenture-federal-services-and-google-public-sector-launch-cybersecurity-center-of-excellence

