### PR TITLE
open pdf in new tab instead of save by default

### DIFF
--- a/blocks/aside/aside.js
+++ b/blocks/aside/aside.js
@@ -41,7 +41,11 @@ async function generatePDF(pageName) {
     jsPDF: { unit: 'pt', format: 'letter', orientation: 'portrait' },
     pagebreak: { mode: ['avoid-all', 'css', 'legacy'] },
   };
-  html2pdf().set(opt).from(main).save();
+  html2pdf().set(opt).from(main).toPdf()
+    .get('pdf')
+    .then((pdf) => {
+      window.open(pdf.output('bloburl'), '_blank');
+    });
 }
 
 /**


### PR DESCRIPTION

Fix #354 

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/
- After: https://pdf-new-tab--accenture-newsroom--hlxsites.hlx.page/

