### PR TITLE
Revert "open pdf in new tab instead of save by default"

### DIFF
--- a/blocks/aside/aside.js
+++ b/blocks/aside/aside.js
@@ -41,11 +41,7 @@ async function generatePDF(pageName) {
     jsPDF: { unit: 'pt', format: 'letter', orientation: 'portrait' },
     pagebreak: { mode: ['avoid-all', 'css', 'legacy'] },
   };
-  html2pdf().set(opt).from(main).toPdf()
-    .get('pdf')
-    .then((pdf) => {
-      window.open(pdf.output('bloburl'), '_blank');
-    });
+  html2pdf().set(opt).from(main).save();
 }
 
 /**


### PR DESCRIPTION
Reverts hlxsites/accenture-newsroom#371

https://github.com/hlxsites/accenture-newsroom/issues/354

Hi @amol-anand @ravkiran , there was a confusion with this bug https://github.com/hlxsites/accenture-newsroom/issues/354 and IIiyaz and Eula is asking to revert this changes.
![image](https://github.com/hlxsites/accenture-newsroom/assets/142872664/c694d11c-12e8-4372-87ec-0f0b2671380f)
