### PR TITLE
fix: captions styling in article

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -318,6 +318,18 @@ body.article main .section h1 {
   margin: 0;
 }
 
+body.article main h6 {
+  text-align: center;
+}
+
+body.article main h6 em {
+  text-align: center;
+  font-family: var(--header-font-family-regular);
+  font-weight: 100;
+  font-size: 12px;
+  line-height: 1.6em;
+}
+
 body.article main .section.abstract h6 {
   text-align: center;
   font-family: var(--header-font-family-regular);
@@ -325,6 +337,13 @@ body.article main .section.abstract h6 {
   font-size: 1rem;
   line-height: 1.6em;
   margin: 20px 0;
+}
+
+body.article main picture+em {
+  font-size: 12px;
+  display: flex;
+  justify-content: center;
+  text-align: center;
 }
 
 body.article main .section .article-end-divider {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #359 
Fix #361 

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.live/news/2023/accenture-invests-in-looking-glass-to-accelerate-shift-from-2d-to-3d
- After: https://article-captions--accenture-newsroom--hlxsites.hlx.live/news/2023/accenture-invests-in-looking-glass-to-accelerate-shift-from-2d-to-3d
- After: https://article-captions--accenture-newsroom--hlxsites.hlx.live/news/2023/growing-consumer-and-business-interest-in-the-metaverse-expected-to-fuel-trillion-dollar-opportunity-for-commerce-accenture-finds

