### PR TITLE
fix: don't style mailto links as buttons

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -568,7 +568,7 @@ export function decorateTemplateAndTheme() {
 export function decorateButtons(element) {
   element.querySelectorAll('a').forEach((a) => {
     a.title = a.title || a.textContent;
-    if (a.href !== a.textContent) {
+    if (a.href !== a.textContent && a.href.indexOf('mailto:') === -1) {
       const up = a.parentElement;
       const twoup = a.parentElement.parentElement;
       if (!a.querySelector('img')) {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix Don't style mailto links as buttons

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.live/news/2013/accenture-and-the-challenged-athletes-foundation-to-support-injured-troops-at-ironman-70-3-california
- After: https://button-style--accenture-newsroom--hlxsites.hlx.live/news/2013/accenture-and-the-challenged-athletes-foundation-to-support-injured-troops-at-ironman-70-3-california

