### PR TITLE
fix: styling mailto a tags

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -232,6 +232,16 @@ button.secondary {
   color: var(--secondary-link-color);
 }
 
+/* style mailto links as normal links rather than buttons */
+
+a.primary.button[href^="mailto"] {
+  color: var(--link-color);
+  font-family: var(--body-font-family);
+  text-transform: none;
+  font-size: var(--body-font-size-default);
+  font-weight: 100;
+}
+
 body.article p.button-container strong a.primary {
   display: inline-block;
   color: #fff;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix styling mailto a tags

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.live/news/2012/united-bank-of-india-awards-accenture-two-year-management-consulting-agreement-to-support-its-strategic-transformation-program
- After: https://mailto--accenture-newsroom--hlxsites.hlx.live/news/2012/united-bank-of-india-awards-accenture-two-year-management-consulting-agreement-to-support-its-strategic-transformation-program

