### PR TITLE
fix: applying article h1 styling to h2 and h3 as well

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -356,7 +356,9 @@ body.article main .section.abstract p.date {
   margin: 0;
 }
 
-body.article main .section h1 {
+body.article main .section h1,
+body.article main .section h2,
+body.article main .section h3 {
   text-align: center;
   font-family: var(--header-font-family-regular);
   font-weight: 700;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -357,8 +357,8 @@ body.article main .section.abstract p.date {
 }
 
 body.article main .section h1,
-body.article main .section h2,
-body.article main .section h3 {
+body.article main .section.abstract h2,
+body.article main .section.abstract h3 {
   text-align: center;
   font-family: var(--header-font-family-regular);
   font-weight: 700;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix applying article h1 styling to h2 and h3 as well to fix the headings in geo sites

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.live/news/2023/accenture-collaborates-with-sap-to-help-organizations-adopt-generative-ai-and-accelerate-erp-transformation-in-the-cloud
- After: https://heading-styling--accenture-newsroom--hlxsites.hlx.live/news/2023/accenture-collaborates-with-sap-to-help-organizations-adopt-generative-ai-and-accelerate-erp-transformation-in-the-cloud

