### PR TITLE
fix: use the abstract for description when regex match not found

### DIFF
--- a/blocks/newslist/newslist.js
+++ b/blocks/newslist/newslist.js
@@ -51,6 +51,22 @@ function getHumanReadableDate(dateString) {
 }
 
 /**
+ * Removes the heading and list elements from the given element
+ *
+ * @param {*} element
+ */
+function cleanDescription(element) {
+  const elementsToRemove = ['h1', 'h2', 'h3', 'h6', 'ul'];
+  elementsToRemove.forEach((e) => {
+    const el = element.querySelector(e);
+    if (el) {
+      el.remove();
+    }
+  });
+  return element.innerHTML;
+}
+
+/**
  * In the longdescrptionextracted field, iterate over all the child nodes and
  * check if the content matches with the regex, then return it as description.
  * Oterwise return the description field.
@@ -68,10 +84,18 @@ function getDescription(queryIndexEntry) {
     oBr.remove();
   }
   let longdescription = matchingParagraph ? matchingParagraph.outerHTML : '';
+  if (longdescription === '') {
+    // obtain the description with out regex matching
+    longdescription = cleanDescription(div);
+  }
   if (queryIndexEntry.description.length > longdescription.length) {
     longdescription = `<p>${queryIndexEntry.description}</p>`;
   } else if (longdescription.length > MAX_CHARS_IN_CARD_DESCRIPTION) {
-    longdescription = `<p>${matchingParagraph.innerHTML.substring(0, MAX_CHARS_IN_CARD_DESCRIPTION)}...</p>`;
+    if (matchingParagraph) {
+      longdescription = `<p>${matchingParagraph.innerHTML.substring(0, MAX_CHARS_IN_CARD_DESCRIPTION)}...</p>`;
+    } else {
+      longdescription = `<p>${longdescription.substring(0, MAX_CHARS_IN_CARD_DESCRIPTION)}...</p>`;
+    }
   }
   const wrapper = document.createElement('div');
   wrapper.innerHTML = longdescription;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix 

If the regex match is not found, currently we're only showing the title, this is happening more in geo sites
This fix will use the abstract by cleaning up headings in case the regex match not found

Please check on https://description-update--accenture-newsroom--hlxsites.hlx.live?page=524

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.live/
- After: https://description-update--accenture-newsroom--hlxsites.hlx.live/

