### PR TITLE
Fix: Revert the arrow icon for the home hero cta

### DIFF
--- a/blocks/home-hero/home-hero.css
+++ b/blocks/home-hero/home-hero.css
@@ -82,6 +82,15 @@
   display: none;
 }
 
+.home-hero.block .overlay-container a::after {
+  content: '';
+  display: inline-block;
+  height: 20px;
+  width: 40px;
+  line-height: 20px;
+  background: transparent url('/icons/arrow-icon.svg') no-repeat 0 -8px;
+}
+
 .home-hero.block .home-hero-content-container .overlay-container h2 a{
   color: #000;
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://github.com/hlxsites/accenture-newsroom/issues/417

- https://github.com/hlxsites/accenture-newsroom/issues/417

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/
- After: https://home-hero-cta--accenture-newsroom--hlxsites.hlx.page/

