### PR TITLE
Fix: Add hyperlink search functionality to the page not found message

### DIFF
--- a/404.html
+++ b/404.html
@@ -51,12 +51,22 @@
       });
     }
 
+    // Add home page "search functionality" link to the error message
+    const addLinkToErrorMessage = (sErrorMessage = '', sLinkText) => {
+      const sRegex = new RegExp('{searchFunctionality}', 'gi');
+      const sReplacedText = sErrorMessage.replace(sRegex, `<a href="/">${sLinkText}</a>`);
+      return sReplacedText;
+    };
+
     window.addEventListener('load', async () => {
       const filterForm = document.getElementById('filter-form');
       const years = getYearsFrom(parseInt(filterForm.dataset.year, 10));
       const placeholders = await fetchPlaceholders();
       const pYear = getPlaceholder('year', placeholders);
       const pMessage = getPlaceholder('pageNotFoundMessage', placeholders);
+      const searchFunctionality = getPlaceholder('searchFunctionality', placeholders);
+      const sHomeLinkText = searchFunctionality === 'searchFunctionality' ? 'search functionality' : searchFunctionality;
+      const pUpdatedMessage = addLinkToErrorMessage(pMessage, sHomeLinkText);
       const pReturnButtonText = getPlaceholder('returnButtonText', placeholders);
       const pFilterNews = getPlaceholder('filterNews', placeholders);
       const pDateRange = getPlaceholder('dateRange', placeholders);
@@ -67,7 +77,7 @@
       filterInput.title = pDateRange;
       const filterYear = await createFilterYear(years, pYear, '/');
       filterForm.appendChild(filterYear);
-      const message = `<p>${pMessage}</p>`;
+      const message = `<p>${pUpdatedMessage}</p>`;
       const messageContainer = document.createElement('div');
       messageContainer.classList.add('error-message');
       messageContainer.innerHTML = message;

--- a/404.html
+++ b/404.html
@@ -51,10 +51,10 @@
       });
     }
 
-    // Add home page "search functionality" link to the error message
+    // Add search page "search functionality" link to the error message
     const addLinkToErrorMessage = (sErrorMessage = '', sLinkText) => {
       const sRegex = new RegExp('{searchFunctionality}', 'gi');
-      const sReplacedText = sErrorMessage.replace(sRegex, `<a href="/">${sLinkText}</a>`);
+      const sReplacedText = sErrorMessage.replace(sRegex, `<a href="/search">${sLinkText}</a>`);
       return sReplacedText;
     };
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://github.com/hlxsites/accenture-newsroom/issues/430

- https://github.com/hlxsites/accenture-newsroom/issues/430

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/123
- After: https://123708-pnf-message--accenture-newsroom--hlxsites.hlx.page/123

I also updated the pageNotFoundMessage placeholder and add new placeholder "Search Functionality" for the translation use case when implemented to the other local geo in the future.
![image](https://github.com/hlxsites/accenture-newsroom/assets/142872664/5ccf2cc4-882a-4642-9be6-906f34a8e513)


