### PR TITLE
Fix: Implement pdfLinkHandler regardless of the template

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -513,15 +513,25 @@ const centerArticleDivider = (main) => {
   });
 };
 
-const pdfLinkHandler = (link) => {
-  const href = link.getAttribute('href');
-  if (!href) {
-    return;
-  }
-  if (!href.includes('.pdf')) {
-    return;
-  }
-  link.setAttribute('target', '_blank');
+const pdfLinkHandler = () => {
+  const sections = document.querySelectorAll('main > .section');
+
+  const addTargetAttribute = (link) => {
+    const href = link.getAttribute('href');
+    if (!href) {
+      return;
+    }
+    if (!href.includes('.pdf')) {
+      return;
+    }
+    link.setAttribute('target', '_blank');
+  };
+
+  sections.forEach((oElem) => {
+    oElem.querySelectorAll('a').forEach((link) => {
+      addTargetAttribute(link);
+    });
+  });
 };
 
 function annotateArticleSections() {
@@ -556,7 +566,6 @@ function annotateArticleSections() {
           ANALYTICS_TEMPLATE_ZONE_BODY,
           ANALYTICS_LINK_TYPE_CONTENT_MODULE,
         );
-        pdfLinkHandler(link);
       });
     } else {
       section.querySelectorAll('a').forEach((link) => {
@@ -567,7 +576,6 @@ function annotateArticleSections() {
           ANALYTICS_TEMPLATE_ZONE_BODY,
           ANALYTICS_LINK_TYPE_CONTENT_MODULE,
         );
-        pdfLinkHandler(link);
       });
     }
   });
@@ -652,6 +660,7 @@ async function loadEager(doc) {
     decorateMain(main);
     // article processing
     annotateArticleSections();
+    pdfLinkHandler();
     document.body.classList.add('appear');
     await waitForLCP(LCP_BLOCKS);
   }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -514,7 +514,7 @@ const centerArticleDivider = (main) => {
 };
 
 const pdfLinkHandler = () => {
-  const sections = document.querySelectorAll('main > .section');
+  const sectionLinks = document.querySelectorAll('main > .section a');
 
   const addTargetAttribute = (link) => {
     const href = link.getAttribute('href');
@@ -527,10 +527,8 @@ const pdfLinkHandler = () => {
     link.setAttribute('target', '_blank');
   };
 
-  sections.forEach((oElem) => {
-    oElem.querySelectorAll('a').forEach((link) => {
-      addTargetAttribute(link);
-    });
+  sectionLinks.forEach((link) => {
+    addTargetAttribute(link);
   });
 };
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://github.com/hlxsites/accenture-newsroom/issues/433

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/news/2023/accenture-reports-fourth-quarter-and-strong-full-year-fiscal-2023-results
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/earnings-infographics
- After: https://inline-pdf-link--accenture-newsroom--hlxsites.hlx.page/news/2023/accenture-reports-fourth-quarter-and-strong-full-year-fiscal-2023-results
- After: https://inline-pdf-link--accenture-newsroom--hlxsites.hlx.page/earnings-infographics

