### PR TITLE
fix: adding href for disabled arrows in pagination for improving SEO score

### DIFF
--- a/blocks/newslist/newslist.js
+++ b/blocks/newslist/newslist.js
@@ -319,6 +319,7 @@ function updatePagination(paginationContainer, totalResults, pageOffset) {
     const prev = document.createElement('a');
     if (pageOffset === 1) {
       prev.setAttribute('aria-disabled', 'true');
+      prev.setAttribute('href', '#');
     } else {
       prev.setAttribute('href', addParam('page', pageOffset - 1));
     }
@@ -329,6 +330,7 @@ function updatePagination(paginationContainer, totalResults, pageOffset) {
     const next = document.createElement('a');
     if (pageOffset === totalPages) {
       next.setAttribute('aria-disabled', 'true');
+      next.setAttribute('href', '#');
     } else {
       next.setAttribute('href', addParam('page', pageOffset + 1));
     }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix SEO score

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.live/
- After: https://seo-pagination--accenture-newsroom--hlxsites.hlx.live/

