### PR TITLE
fix: removing word boundaries from abstract finding regex

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -32,7 +32,7 @@ import {
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 
 // regex to find abstract paragraph
-export const ABSTRACT_REGEX = /(.*?);.*?(\d{4})|(.*?)(\d{4})\s+–\s+\b|(.*?)(\d{4})\s+-\s+\b/;
+export const ABSTRACT_REGEX = /(.*?);.*?(\d{4})|(.*?)(\d{4})\s+–\s+|(.*?)(\d{4})\s+-\s+/;
 
 export const isMobile = () => window.innerWidth < 600;
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -32,7 +32,7 @@ import {
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 
 // regex to find abstract paragraph
-export const ABSTRACT_REGEX = /(.*?);.*?(\d{4})|(.*?)(\d{4})\s+–\s+|(.*?)(\d{4})\s+-\s+/;
+export const ABSTRACT_REGEX = /(.*?);.*?(\d{4})|(.*?)(\d{4})\s+(–|-|‒)\s+/;
 
 export const isMobile = () => window.innerWidth < 600;
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -32,7 +32,7 @@ import {
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 
 // regex to find abstract paragraph
-export const ABSTRACT_REGEX = /(.*?);.*?(\d{4})|(.*?)(\d{4})\s+(–|-|‒)\s+/;
+export const ABSTRACT_REGEX = /(.*?);.*?(\d{4})|(.*?)(\d{4})\s*(–|-|‒|:)\s*/;
 
 export const isMobile = () => window.innerWidth < 600;
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix Removing the word boundaries restriction from abstract regex
https://newsroom.accenturebr.com/br/news/2022/estrategia-de-tecnologia-sustentavel-e-fundamental-para-alcancar-crescimento-dos-negocios-e-desempenho-esg
The lang characters in the string 
```
NOVA YORK, 6 de julho de 2022 – À medida que as empresas definem metas ambientais, sociais e de governança (ESG, em inglês) cada vez mais ambiciosas, suas estratégias de sustentabilidade e tecnologia precisam estar alinhadas para garantir vantagem competitiva, valor financeiro e um impacto positivo duradouro na sociedade e no meio ambiente. É o que mostra o novo levantamento conduzido pela Accenture (NYSE: ACN). Todavia, as estratégias de negócios, tecnologia e sustentabilidade de apenas 7% dos entrevistados já estão totalmente integradas.
```
are not matching the word boundaries `\b` in the regex

Word boundaries isn't a mandatory, given that we're only using regex now listing, so removing that restriction.

Also added match for Figure Dash which is used in [this article](https://newsroom.accenturebr.com/br/news/2022/accenture-nomeia-brasileiro-leonardo-framil-ceo-para-mercados-em-crescimento) in abstract and simplified the regex. 
Now abstract will match the following dashes
<img width="752" alt="image" src="https://github.com/hlxsites/accenture-newsroom/assets/1553152/cbc97fbc-645f-4f35-a36a-f341b65bb0c8">



Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.live/
- After: https://abstract-regex--accenture-newsroom--hlxsites.hlx.live/

