### PR TITLE
Fix: add italic h5 and include h5 to clean up description

### DIFF
--- a/blocks/newslist/newslist.js
+++ b/blocks/newslist/newslist.js
@@ -56,7 +56,7 @@ function getHumanReadableDate(dateString) {
  * @param {*} element
  */
 function cleanDescription(element) {
-  const elementsToRemove = ['h1', 'h2', 'h3', 'h6', 'ul'];
+  const elementsToRemove = ['h1', 'h2', 'h3', 'h5', 'h6', 'ul'];
   elementsToRemove.forEach((e) => {
     const el = element.querySelector(e);
     if (el) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -414,10 +414,11 @@ body.article main picture+em {
   text-align: center;
 }
 
-body.article main .section.abstract h5 em{
+body.article main .section.abstract h5 em ~ h5 {
   font-size: var(--body-font-size-default);
   font-family: var(--body-font-family);
   font-weight: 400;
+  line-height: 25.6px;
 }
 
 body.article main .section .article-end-divider {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -414,6 +414,12 @@ body.article main picture+em {
   text-align: center;
 }
 
+body.article main .section.abstract h5 em{
+  font-size: var(--body-font-size-default);
+  font-family: var(--body-font-family);
+  font-weight: 400;
+}
+
 body.article main .section .article-end-divider {
   display: inline-block;
   width: 100%;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

for the special case, article with italic element (p > em ) above date on abstract needs to include on the clean up description. 
Added styling for the h5 > em therefore we can update the word docs and use heading 5 then will exclude on the description on the news card.

https://newsroom.accenturebr.com/?page=5
![image](https://github.com/hlxsites/accenture-newsroom/assets/142872664/d8c04afa-70eb-4bf2-9844-64625d1383ed)
![image](https://github.com/hlxsites/accenture-newsroom/assets/142872664/4eb3e61c-d58f-48ff-a9bd-4d185031abb6)



Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/
- After: https://newscard-desc--accenture-newsroom--hlxsites.hlx.page/

