### PR TITLE
Fix: Include h5 to cleanDescription

### DIFF
--- a/blocks/newslist/newslist.js
+++ b/blocks/newslist/newslist.js
@@ -56,7 +56,7 @@ function getHumanReadableDate(dateString) {
  * @param {*} element
  */
 function cleanDescription(element) {
-  const elementsToRemove = ['h1', 'h2', 'h3', 'h6', 'ul'];
+  const elementsToRemove = ['h1', 'h2', 'h3', 'h5', 'h6', 'ul'];
   elementsToRemove.forEach((e) => {
     const el = element.querySelector(e);
     if (el) {


### PR DESCRIPTION
There's an article which the title needs to author as h5 and no regex detected. 
Since there's no h5 on the cleanDescription it got included to the description of the newscard

https://newsroom.accenture.pt/
![image](https://github.com/hlxsites/accenture-newsroom/assets/142872664/a5648f5d-1759-41e9-956b-bd71262f47d1)
![image](https://github.com/hlxsites/accenture-newsroom/assets/142872664/4d2bf184-6406-4f6a-b30c-6b2e5ef41f90)

Tekgroup
https://accenturept.tekgroupweb.com/pt/news/consumidores-nivel-global-planeiam-manter-ou-aumentar-os-gastos-em-viagens-nos-proximos-meses.htm

Franklin
https://newsroom.accenture.pt/pt/news/2023/consumidores-nivel-global-planeiam-manter-ou-aumentar-os-gastos-em-viagens-nos-proximos-meses


Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix 

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/
- After: https://h5-abstract--accenture-newsroom--hlxsites.hlx.page/

