### PR TITLE
Fix: Update abstract regex for the other format of description date

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -32,7 +32,7 @@ import {
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 
 // regex to find abstract paragraph
-export const ABSTRACT_REGEX = /(.*?);.*?(\d{4})|(.*?)(\d{4})\s+–\s+\b|(.*?)(\d{4})\s+-\s+\b/;
+export const ABSTRACT_REGEX = /(.*?);.*?(\d{4})|(.*?)(\d{4})\s+(–|-|‒)\s+|(.*?)(\d{4} (–|-|‒|:))(.)|(.*?)(\d{4}(–|-|‒|:)(.))/;
 
 export const isMobile = () => window.innerWidth < 600;
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix 
https://github.com/hlxsites/accenture-newsroom/pull/438 - I added capture on this regex to capture other format of date. 
Condition

1. Lisboa, 28 de junho de 2023 - A Accenture Portugal e a 
2. Lisboa, 28 de junho de 2023- A Accenture Portugal e a
3. Lisboa, 28 de junho de 2023 -A Accenture Portugal e a
4. Lisboa, 28 de junho de 2023-A Accenture Portugal e a 
5. Lisboa, 28 de junho de 2023 : A Accenture Portugal e a 
6. Lisboa, 28 de junho de 2023: A Accenture Portugal e a 
7. Lisboa, 28 de junho de 2023 :A Accenture Portugal e a
8. Lisboa, 28 de junho de 2023:A Accenture Portugal e a 

Test URLs:
- Before: https://newsroom.accenture.pt/
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/
- After: https://regex-abstract-news--accenture-newsroom--hlxsites.hlx.page/

