### PR TITLE
Refactor: Convert article date p tag to div tag

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -32,7 +32,7 @@ import {
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 
 // regex to find abstract paragraph
-export const ABSTRACT_REGEX = /(.*?);.*?(\d{4})|(.*?)(\d{4})\s*(–|-|‒|:)\s*/;
+export const ABSTRACT_REGEX = /(.*?);.*?(\d{4})|(.*?)(\d{4})\s+–\s+\b|(.*?)(\d{4})\s+-\s+\b/;
 
 export const isMobile = () => window.innerWidth < 600;
 
@@ -531,6 +531,25 @@ const pdfLinkHandler = () => {
     addTargetAttribute(link);
   });
 };
+const convertPublishedDate = (dateString) => {
+  const dateObject = new Date(dateString);
+  const options = { year: 'numeric', month: 'long', day: 'numeric' };
+  const formattedDate = dateObject.toLocaleDateString('en-US', options);
+  return formattedDate;
+}
+
+const createHiddenPublishedDate = (parentElement) => {
+  const publishedDate = getMetadata('publisheddate');
+  if (!publishedDate) {
+    return;
+  }
+  const divDate = document.createElement('div');
+
+  divDate.innerHTML = convertPublishedDate(publishedDate);
+  divDate.classList.add('date');
+  divDate.style.display = 'none';
+  parentElement.insertAdjacentHTML('afterbegin', divDate.outerHTML);
+};
 
 function annotateArticleSections() {
   const template = getMetadata('template');
@@ -543,9 +562,16 @@ function annotateArticleSections() {
   const h1 = abstractSection.querySelector('h1');
   if (h1) {
     const date = h1.previousSibling;
-    if (date) {
-      date.classList.add('date');
+    const h1ParentElement = h1.parentNode;
+    if (!date) {
+      createHiddenPublishedDate(h1ParentElement);
+      return;
     }
+    const divDate = document.createElement('div');
+    divDate.innerHTML = date.innerHTML;
+    divDate.classList.add('date');
+    h1ParentElement.insertAdjacentHTML('afterbegin', divDate.outerHTML);
+    date.remove();
   }
   // annotate links
   const articleSections = document.querySelectorAll('main > .section');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -536,7 +536,7 @@ const convertPublishedDate = (dateString) => {
   const options = { year: 'numeric', month: 'long', day: 'numeric' };
   const formattedDate = dateObject.toLocaleDateString('en-US', options);
   return formattedDate;
-}
+};
 
 const createHiddenPublishedDate = (parentElement) => {
   const publishedDate = getMetadata('publisheddate');

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -357,7 +357,7 @@ body.article main .section.abstract+.section {
   margin-left: 10px;
 }
 
-body.article main .section.abstract p.date {
+body.article main .section.abstract div.date {
   font-family: var(--graphik-semibold);
   font-size: 12px;
   font-weight: 600;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Issue: A.com search page aren't able to search our newsroom pages.

As per discussion to with @raymond-h-dev, as part of resolution. We need to update the article date "p" tag element to "div" element. If no date on the article page then we need to create hidden div date element based from the metadata published date and make it hidden.

Fix 

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.live/news/2023/accenture-completes-acquisition-of-solnet-to-expand-cloud-first-capabilities-in-aotearoa-new-zealand
- Before: https://main--accenture-newsroom--hlxsites.hlx.live/news/2000/accenture-and-asera-inc-team-to-provideinternet-based-business-to-business-demand-chain-solutions
- After: https://article-date-el--accenture-newsroom--hlxsites.hlx.live/news/2023/accenture-completes-acquisition-of-solnet-to-expand-cloud-first-capabilities-in-aotearoa-new-zealand
- After: https://article-date-el--accenture-newsroom--hlxsites.hlx.live/news/2000/accenture-and-asera-inc-team-to-provideinternet-based-business-to-business-demand-chain-solutions


**Article with date** - from "p" tag  to "div" tag
**AS-IS:** 
https://newsroom.accenture.com/news/2023/accenture-completes-acquisition-of-solnet-to-expand-cloud-first-capabilities-in-aotearoa-new-zealand
![image](https://github.com/hlxsites/accenture-newsroom/assets/142872664/9c951892-40d9-4566-8a99-93d7148335d3)


**TO-BE:** 
https://article-date-el--accenture-newsroom--hlxsites.hlx.live/news/2023/accenture-completes-acquisition-of-solnet-to-expand-cloud-first-capabilities-in-aotearoa-new-zealand
![image](https://github.com/hlxsites/accenture-newsroom/assets/142872664/bacc219c-a3ef-4b8a-8a51-a766bdfe7345)



---------------------------
**Article without date** - Add "div" element date hidden
**AS-IS:**
https://newsroom.accenture.com/news/2000/accenture-and-asera-inc-team-to-provideinternet-based-business-to-business-demand-chain-solutions
![image](https://github.com/hlxsites/accenture-newsroom/assets/142872664/545507b1-31e4-4f2b-8595-7abe87c7d118)




**TO-BE:** 
https://article-date-el--accenture-newsroom--hlxsites.hlx.live/news/2000/accenture-and-asera-inc-team-to-provideinternet-based-business-to-business-demand-chain-solutions
![image](https://github.com/hlxsites/accenture-newsroom/assets/142872664/4898c2d5-7c58-4232-b399-f1a5f5da97b9)



 
