### PR TITLE
Fix: Update the twitter share url

### DIFF
--- a/blocks/aside/aside.js
+++ b/blocks/aside/aside.js
@@ -112,7 +112,7 @@ export default async function decorate(block) {
   createEl('div', { class: 'linkedin-share' }, linkedinShare, social);
 
   // Twitter
-  const twitterUrl = `https://twitter.com/share?text=${pageTitle}&url=${pageUrl}`;
+  const twitterUrl = `https://twitter.com/intent/tweet?text=${pageTitle}&url=${pageUrl}`;
   const twitterShare = createAnnotatedLinkEl(
     twitterUrl,
     'twitter',


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Implement the newer version of twitter share
https://developer.twitter.com/en/docs/twitter-for-websites/tweet-button/overview
![image](https://github.com/hlxsites/accenture-newsroom/assets/142872664/1b6770c1-583a-4dde-85a0-6399e111bfb0)

Fix https://github.com/hlxsites/accenture-newsroom/issues/456
- https://github.com/hlxsites/accenture-newsroom/issues/456

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.live/news/2023/accenture-and-avanade-expand-capabilities-to-accelerate-data-readiness-and-generative-ai-adoption-with-microsoft-technology
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/news/2023/accenture-and-avanade-expand-capabilities-to-accelerate-data-readiness-and-generative-ai-adoption-with-microsoft-technology
- After: https://twitter-share--accenture-newsroom--hlxsites.hlx.live/news/2023/accenture-and-avanade-expand-capabilities-to-accelerate-data-readiness-and-generative-ai-adoption-with-microsoft-technology

