### PR TITLE
fix: using redirect for tagger and library for avoiding the 401 and showing the auth

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -7,7 +7,7 @@
       "environments": [
         "edit"
       ],
-      "url": "/tools/tagger/index.html"
+      "url": "/tools/tagger"
     },
     {
       "id": "preflight",
@@ -21,7 +21,7 @@
       "id": "library",
       "title": "Library",
       "environments": [ "edit" ],
-      "url": "/tools/sidekick/library.html",
+      "url": "/tools/sidekick/library",
       "includePaths": [ "**.docx**" ]
     }
   ]


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix 401 issue while accessing tagger and block library.

**Requests to static html pages do not go through the pipeline as of today, so tagger and block library isn't showing the auth. I've added redirects for tagger and library so that these are handled by the pipeline and show the authentication.**

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/tools/sidekick/library
- After: https://tools-auth--accenture-newsroom--hlxsites.hlx.page/tools/sidekick/library
- After: https://tools-auth--accenture-newsroom--hlxsites.hlx.page/tools/tagger

