### PR TITLE
fix: use semibold font for h1/h2/h3 and strong tags

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -372,11 +372,15 @@ body.article main .section h1,
 body.article main .section.abstract h2,
 body.article main .section.abstract h3 {
   text-align: center;
-  font-family: var(--header-font-family-regular);
+  font-family: var(--graphik-semibold);
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.6em;
   margin: 0;
+}
+
+body.article main p strong {
+  font-family: var(--graphik-semibold);
 }
 
 body.article main h6 {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #485

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.live/news/2023/finnish-defence-forces-to-collaborate-with-accenture-on-an-enterprise-resource-planning-transformation-programme-based-on-sap-hana
- After: https://titlestyling--accenture-newsroom--hlxsites.hlx.live/news/2023/finnish-defence-forces-to-collaborate-with-accenture-on-an-enterprise-resource-planning-transformation-programme-based-on-sap-hana

