### PR TITLE
Clean format

### DIFF
--- a/tools/metadata/index.html
+++ b/tools/metadata/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Accenture Newsroom - Metadata Helper</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <script src="/tools/metadata/metadata.js" type="module"></script>
+  <link rel="stylesheet" href="/tools/metadata/metadata.css"/>
+</head>
+<body>
+<main>
+  <div class="intro">
+    <h1 id="pick-your-tags">Metadata Helper</h1>
+    <p>Use this tool to enter the relevant metadata easily paste the content into Word pre-formatted</p>
+  </div>
+  <!-- Form with 4 fields for Publish Date, Title, Abstract and Body -->
+  <form>
+    <label for="publishDate">Publish Date:</label><br>
+    <input type="date" id="publishDate" name="publishDate"><br>
+    <label for="title">Title:</label><br>
+    <input type="text" id="title" name="title"><br>
+    <label for="description">Description:</label><br>
+    <textarea id="description" name="description"></textarea><br>
+    <label for="abstract">Abstract:</label><br>
+    <textarea id="abstract" name="abstract"></textarea><br>
+    <!-- <label for="body">Body:</label><br>
+    <textarea id="body" name="body"></textarea><br> -->
+    <!-- <input type="submit" value="Submit"> -->
+  </form>
+  <div>
+    <button id="copyToClipboard">Copy to Clipboard</button>
+  </div>
+</main>
+</body>
+</html>

--- a/tools/metadata/index.html
+++ b/tools/metadata/index.html
@@ -4,30 +4,42 @@
   <title>Accenture Newsroom - Metadata Helper</title>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <script src="/tools/metadata/metadata.js" type="module"></script>
+  <link rel="stylesheet" href="/styles/fonts.css"/>
+  <link rel="stylesheet" href="/styles/styles.css"/>
   <link rel="stylesheet" href="/tools/metadata/metadata.css"/>
+  <!-- Include the Quill library -->
+  <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+  <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
 </head>
 <body>
 <main>
   <div class="intro">
     <h1 id="pick-your-tags">Metadata Helper</h1>
-    <p>Use this tool to enter the relevant metadata easily paste the content into Word pre-formatted</p>
+    <p>Use this tool to enter the relevant metadata easily and paste the content into Word pre-formatted</p>
   </div>
   <!-- Form with 4 fields for Publish Date, Title, Abstract and Body -->
   <form>
     <label for="publishDate">Publish Date:</label><br>
-    <input type="date" id="publishDate" name="publishDate"><br>
+    <input type="datetime-local" id="publishDate" name="publishDate"><br>
     <label for="title">Title:</label><br>
     <input type="text" id="title" name="title"><br>
     <label for="description">Description:</label><br>
-    <textarea id="description" name="description"></textarea><br>
+    <div id="description" name="description"></div><br>
     <label for="abstract">Abstract:</label><br>
-    <textarea id="abstract" name="abstract"></textarea><br>
+    <div id="abstract" name="abstract"></div><br>
+    <label for="dropdown-subjects">Subject Tags:</label><br>
+    <select id="dropdown-subjects" multiple></select><br>
+    <label for="dropdown-industries">Industry Tags:</label><br>
+    <select id="dropdown-industries" multiple></select><br>
     <!-- <label for="body">Body:</label><br>
     <textarea id="body" name="body"></textarea><br> -->
-    <!-- <input type="submit" value="Submit"> -->
+    <!-- <input type="submit" value="Copy to Clipboard" onsubmit="processForm()"> -->
   </form>
   <div>
     <button id="copyToClipboard">Copy to Clipboard</button>
+    <div id="customAlert" style="display: none; background-color: yellow; padding: 10px;">
+      Metadata copied to the clipboard
+    </div>
   </div>
 </main>
 </body>

--- a/tools/metadata/index.html
+++ b/tools/metadata/index.html
@@ -15,7 +15,7 @@
 <main>
   <div class="intro">
     <h1 id="pick-your-tags">Metadata Helper</h1>
-    <p>Use this tool to enter the relevant metadata easily and paste the content into Word pre-formatted</p>
+    <p>Use this tool to enter relevant metadata and paste the content into Word pre-formatted</p>
   </div>
   <!-- Form with 4 fields for Publish Date, Title, Abstract and Body -->
   <form>
@@ -23,21 +23,20 @@
     <input type="datetime-local" id="publishDate" name="publishDate"><br>
     <label for="title">Title:</label><br>
     <input type="text" id="title" name="title"><br>
-    <label for="description">Description:</label><br>
-    <div id="description" name="description"></div><br>
+    <label for="subtitle">Subtitle:</label><br>
+    <input type="text" id="subtitle" name="subtitle"><br>
     <label for="abstract">Abstract:</label><br>
     <div id="abstract" name="abstract"></div><br>
+    <label for="body">Body:</label><br>
+    <div id="body" name="body"></div><br>
     <label for="dropdown-subjects">Subject Tags:</label><br>
-    <select id="dropdown-subjects" multiple></select><br>
+    <select id="dropdown-subjects" multiple></select><br><br>
     <label for="dropdown-industries">Industry Tags:</label><br>
-    <select id="dropdown-industries" multiple></select><br>
-    <!-- <label for="body">Body:</label><br>
-    <textarea id="body" name="body"></textarea><br> -->
-    <!-- <input type="submit" value="Copy to Clipboard" onsubmit="processForm()"> -->
+    <select id="dropdown-industries" multiple></select><br><br>
   </form>
   <div>
-    <button id="copyToClipboard">Copy to Clipboard</button>
-    <div id="customAlert" style="display: none; background-color: yellow; padding: 10px;">
+    <button id="copy-to-clipboard">Copy to Clipboard</button>
+    <div id="custom-alert" style="display: none; background-color: yellow; padding: 10px;">
       Metadata copied to the clipboard
     </div>
   </div>

--- a/tools/metadata/metadata.css
+++ b/tools/metadata/metadata.css
@@ -1,0 +1,1 @@
+/* nothing here yet */

--- a/tools/metadata/metadata.css
+++ b/tools/metadata/metadata.css
@@ -12,7 +12,7 @@ label {
   font-weight: bolder;
 }
 
-select, div#abstract, div#description {
+select, div#abstract, div#body {
   width: 100%;
   max-width: 50rem;
   height: 200px;
@@ -20,4 +20,9 @@ select, div#abstract, div#description {
 
 .ql-toolbar {
   max-width: 50rem;
+}
+
+button#copy-to-clipboard {
+  min-width: 50rem;
+  line-height: 200%;
 }

--- a/tools/metadata/metadata.css
+++ b/tools/metadata/metadata.css
@@ -1,1 +1,23 @@
 /* nothing here yet */
+
+body {
+  display: unset;
+}
+
+main {
+  padding: 5%;
+}
+
+label {
+  font-weight: bolder;
+}
+
+select, div#abstract, div#description {
+  width: 100%;
+  max-width: 50rem;
+  height: 200px;
+}
+
+.ql-toolbar {
+  max-width: 50rem;
+}

--- a/tools/metadata/metadata.js
+++ b/tools/metadata/metadata.js
@@ -1,0 +1,1 @@
+// nothing here yet

--- a/tools/metadata/metadata.js
+++ b/tools/metadata/metadata.js
@@ -1,1 +1,128 @@
-// nothing here yet
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-undef */
+
+function showAlert() {
+  const alertBox = document.getElementById('customAlert');
+  alertBox.style.display = 'block';
+  setTimeout(() => {
+    alertBox.style.display = 'none';
+  }, 4000); // Dismiss after 4 seconds
+}
+
+function writeToClipboard(blob) {
+  const data = [new ClipboardItem({ [blob.type]: blob })];
+  navigator.clipboard.write(data);
+}
+
+async function populateTags() {
+  // Replace with your JSON endpoint
+  const tags = '/tags.json';
+  const url = new URL(tags, window.location.origin);
+  const resp = await fetch(url.toString());
+  const response = await resp.json();
+  if (response) {
+    const { data } = response;
+    const subjects = data.map((item) => item.Subjects);
+    subjects.sort();
+    const industries = data.map((item) => item.Industries);
+    industries.sort();
+    const selectSubjects = document.getElementById('dropdown-subjects');
+    subjects.forEach((item) => {
+      if (item) {
+        const option = document.createElement('option');
+        option.value = item;
+        option.text = item;
+        selectSubjects.appendChild(option);
+      }
+    });
+    const selectIndustries = document.getElementById('dropdown-industries');
+    industries.forEach((item) => {
+      if (item) {
+        const option = document.createElement('option');
+        option.value = item;
+        option.text = item;
+        selectIndustries.appendChild(option);
+      }
+    });
+  }
+}
+
+function processForm() {
+  const publishDate = document.getElementById('publishDate').value;
+  const title = document.getElementById('title').value;
+  const description = document.querySelector('form div#description .ql-editor').innerHTML;
+  const abstract = document.querySelector('form div#abstract .ql-editor').innerHTML;
+  const subjectsDropdown = document.getElementById('dropdown-subjects');
+  const selectedSubjects = Array
+    .from(subjectsDropdown.selectedOptions)
+    .map((option) => option.value);
+  const subjects = selectedSubjects.join(', ');
+  const industriesDropdown = document.getElementById('dropdown-industries');
+  const selectedIndustries = Array
+    .from(industriesDropdown.selectedOptions)
+    .map((option) => option.value);
+  const industries = selectedIndustries.join(', ');
+  // create the html to paste into the word doc
+  const htmlToPaste = `
+    <h1>${title}</h1>
+    <br>
+    ${abstract}
+    ---
+
+    <table border="1">
+      <tr bgcolor="#f7caac">
+        <td colspan="2">Metadata</td>
+      </tr>
+      <tr>
+        <td>Published Date</td>
+        <td>${publishDate}</td>
+      </tr>
+      <tr>
+        <td>Title</td>
+        <td>${title}</td>
+      </tr>
+      <tr>
+        <td>Description</td>
+        <td>${description}</td>
+      </tr>
+      <tr>
+        <td>Abstract</td>
+        <td>${abstract}</td>
+      </tr>
+      <tr>
+        <td>Subjects</td>
+        <td>${subjects}</td>
+      </tr>
+      <tr>
+        <td>Industries</td>
+        <td>${industries}</td>
+      </tr>
+    </table>
+  `;
+  writeToClipboard(new Blob([htmlToPaste], { type: 'text/html' }));
+  showAlert();
+}
+
+async function init() {
+  await populateTags();
+  const rteOptions = {
+    modules: {
+      toolbar: [
+        ['bold', 'italic', 'underline'],
+        ['link'],
+        ['clean'],
+      ],
+    },
+    theme: 'snow',
+  };
+  const descContainer = document.querySelector('form div#description');
+  const descriptionEditor = await new Quill(descContainer, rteOptions);
+  const abstractContainer = document.querySelector('form div#abstract');
+  const abstractEditor = await new Quill(abstractContainer, rteOptions);
+  const copyButton = document.getElementById('copyToClipboard');
+  copyButton.addEventListener('click', () => {
+    processForm();
+  });
+}
+
+await init();

--- a/tools/metadata/metadata.js
+++ b/tools/metadata/metadata.js
@@ -1,7 +1,11 @@
 /* eslint-disable prefer-destructuring */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-undef */
-const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+
+function getLocale() {
+  return (navigator.languages && navigator.languages.length)
+    ? navigator.languages[0] : navigator.language;
+}
 
 function showAlert() {
   const alertBox = document.getElementById('custom-alert');
@@ -55,7 +59,9 @@ function processForm() {
   const publishDate = document.getElementById('publishDate').value || new Date().toISOString();
   const publishDateMetadata = publishDate.replace('T', ' ');
   const publishDateObj = new Date(publishDate);
-  const publishDateFormatted = `${months[publishDateObj.getMonth()]} ${publishDateObj.getDate()}, ${publishDateObj.getFullYear()}`;
+  const formattedDateLong = new Intl.DateTimeFormat(getLocale(), {
+    dateStyle: 'long',
+  }).format(publishDateObj);
   const title = document.getElementById('title').value;
   const subTitle = document.getElementById('subtitle').value;
   const rawAbstract = document.querySelector('form div#abstract .ql-editor').innerHTML;
@@ -74,7 +80,7 @@ function processForm() {
   const industries = selectedIndustries.join(', ');
   // create the html to paste into the word doc
   const htmlToPaste = `
-    ${publishDateFormatted || ''}
+    ${formattedDateLong || ''}
     <h1>${title || ''}</h1>
     <h6>${subTitle || ''}</h6>
     <br>
@@ -140,7 +146,7 @@ async function init() {
   const abstractEditor = await new Quill(abstractContainer, rteOptions);
   const bodyContainer = document.querySelector('form div#body');
   const bodyEditor = await new Quill(bodyContainer, rteOptions);
-  const copyButton = document.getElementById('copyToClipboard');
+  const copyButton = document.getElementById('copy-to-clipboard');
   copyButton.addEventListener('click', () => {
     processForm();
   });

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -10,12 +10,12 @@
       "url": "/tools/tagger"
     },
     {
-      "id": "format",
+      "id": "metadata",
       "title": "Metadata",
       "environments": [
         "edit"
       ],
-      "url": "/tools/metadata"
+      "url": "/tools/metadata/index.html"
     },
     {
       "id": "preflight",

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -10,6 +10,14 @@
       "url": "/tools/tagger"
     },
     {
+      "id": "format",
+      "title": "Metadata",
+      "environments": [
+        "edit"
+      ],
+      "url": "/tools/metadata"
+    },
+    {
       "id": "preflight",
       "title": "Preflight",
       "environments": [


### PR DESCRIPTION
Added a sidekick plugin to help with metadata entry and copy to clipboard functionality that will easily allow authors to enter the metadata first and then paste into the document with the correct styles in place to then add / edit other content. 

Already reviewed with the authors and gotten positive feedback that this approach will work.

Fix #520 

Test URLs:
- Before: https://main--accenture-newsroom--hlxsites.hlx.page/
- After: https://clean-format--accenture-newsroom--hlxsites.hlx.page/

